### PR TITLE
Updated filter command based on git-scm.com example

### DIFF
--- a/cmd/rewrite.go
+++ b/cmd/rewrite.go
@@ -126,6 +126,6 @@ done
 	repo, err := git.Open(Dir)
 	CheckIfError(err)
 
-	err = repo.FilterBranch("--env-filter", tpl.String(), "--", "--all")
+	err = repo.FilterBranch("--env-filter", tpl.String(), "--tag-name-filter", "cat", "--", "--all")
 	CheckIfError(err)
 }

--- a/cmd/rewrite.go
+++ b/cmd/rewrite.go
@@ -94,13 +94,13 @@ OLD_EMAILS_{{$i}}=({{range $j, $old := .Old}}{{if $j}} {{end}}"{{$old}}"{{end}})
 CORRECT_NAME_{{$i}}="{{.CorrectName}}"
 CORRECT_EMAIL_{{$i}}="{{.CorrectMail}}"
 for OLD_EMAIL_{{$i}} in ${OLD_EMAILS_{{$i}}[@]}; do
-	if [ "$GIT_COMMITTER_EMAIL" == "$OLD_EMAIL_{{$i}}" ]; then
-		export GIT_COMMITTER_NAME="$CORRECT_NAME_{{$i}}"
-		export GIT_COMMITTER_EMAIL="$CORRECT_EMAIL_{{$i}}"
+	if [ "$GIT_COMMITTER_EMAIL" = "$OLD_EMAIL_{{$i}}" ]; then
+		GIT_COMMITTER_NAME="$CORRECT_NAME_{{$i}}"
+		GIT_COMMITTER_EMAIL="$CORRECT_EMAIL_{{$i}}"
 	fi
-	if [ "$GIT_AUTHOR_EMAIL" == "$OLD_EMAIL_{{$i}}" ]; then
-		export GIT_AUTHOR_NAME="$CORRECT_NAME_{{$i}}"
-		export GIT_AUTHOR_EMAIL="$CORRECT_EMAIL_{{$i}}"
+	if [ "$GIT_AUTHOR_EMAIL" = "$OLD_EMAIL_{{$i}}" ]; then
+		GIT_AUTHOR_NAME="$CORRECT_NAME_{{$i}}"
+		GIT_AUTHOR_EMAIL="$CORRECT_EMAIL_{{$i}}"
 	fi
 done
 {{end}}`)
@@ -126,6 +126,6 @@ done
 	repo, err := git.Open(Dir)
 	CheckIfError(err)
 
-	err = repo.FilterBranch("--env-filter", tpl.String(), "--tag-name-filter", "cat", "-f", "--", "--all")
+	err = repo.FilterBranch("--env-filter", tpl.String(), "--", "--all")
 	CheckIfError(err)
 }


### PR DESCRIPTION
Since git-rewrite-author didn't work for me (command did not rewrite any commit in my repos) I prolonged my web recherche on git author rewriting.
Eventually I stumbled over some official example about how to rewrite authors - this example was a little bit different to what I've found before on the web (of which all seem to be based on https://help.github.com/articles/changing-author-info/).

See https://git-scm.com/docs/git-filter-branch#_examples / Section --env-filter

That slightly different variant of history rewriting did the job for me on my repository.
It might help others too -- so here's the pull request.